### PR TITLE
Bugfix: admin role handling

### DIFF
--- a/Chapter06/MyERC20Token/contracts/MyERC20Token.sol
+++ b/Chapter06/MyERC20Token/contracts/MyERC20Token.sol
@@ -33,8 +33,8 @@ contract owned {
         admins[account] = true;    
     }
     function removeAdmin(address account) onlyOwner public {
-        require(account != address(0) && !admins[account]);
-        admins[account] = true;    
+        require(account != address(0) && admins[account]);
+        admins[account] = false;    
     }
 }
 /**


### PR DESCRIPTION
removeAdmin() was identical to addAdmin() in the owned contract, i.e. removing an admin account actually added it as admin.